### PR TITLE
Add Logs_syslog_unix.unix_reporter and Logs_syslog_lwt.unix_reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 env:
   global:
     - PACKAGE="logs-syslog"
+    - PINS="syslog-message"
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04

--- a/src/logs_syslog_lwt.ml
+++ b/src/logs_syslog_lwt.ml
@@ -21,24 +21,27 @@ let udp_reporter ?hostname ip ?(port = 514) ?(truncate = 65535) ?facility () =
    | Some x -> Lwt.return x
    | None -> Lwt_unix.gethostname ()) >|= fun host ->
   syslog_report_common facility host truncate Ptime_clock.now send
+                       Syslog_message.encode
 
-let tcp_reporter ?hostname ip ?(port = 514) ?(truncate = 0) ?(framing = `Null) ?facility () =
-  let sa = Lwt_unix.ADDR_INET (ip, port) in
+let conn_reporter sd st sa truncate frame encode hostname facility =
   let s = ref None in
   let m = Lwt_mutex.create () in
-  (match hostname with
-   | Some x -> Lwt.return x
-   | None -> Lwt_unix.gethostname ()) >>= fun host ->
   let connect () =
-    let sock = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
+    let sock = Lwt_unix.(socket sd st 0) in
     Lwt_unix.(setsockopt sock SO_REUSEADDR true) ;
     Lwt_unix.(setsockopt sock SO_KEEPALIVE true) ;
     Lwt.catch
       (fun () -> Lwt_unix.connect sock sa >|= fun () -> s := Some sock ; Ok ())
       (function Unix.Unix_error (e, f, _) ->
+         let endpoint =
+           match sa with
+           | Unix.ADDR_UNIX socket -> socket
+           | Unix.ADDR_INET (ip, port) ->
+               Printf.sprintf "%s:%d" (Unix.string_of_inet_addr ip) port
+         in
          let err =
-           Printf.sprintf "error %s in function %s while connecting to %s:%d"
-             (Unix.error_message e) f (Unix.string_of_inet_addr ip) port
+           Printf.sprintf "error %s in function %s while connecting to %s"
+             (Unix.error_message e) f endpoint
          in
          Lwt.return (Error err))
   in
@@ -57,33 +60,65 @@ let tcp_reporter ?hostname ip ?(port = 514) ?(truncate = 0) ?(framing = `Null) ?
   connect () >>= function
   | Error e -> Lwt.return (Error e)
   | Ok () ->
+    let transmit =
+      if st = Unix.SOCK_DGRAM then
+        fun sock b len () -> Lwt_unix.send sock b 0 len [] >|= fun _ -> ()
+      else
+        fun sock b len () ->
+          let rec aux idx =
+            let should = len - idx in
+            Lwt_unix.send sock b idx (len - idx) [] >>= fun n ->
+              if n = should then
+                Lwt.return_unit
+              else
+                aux (idx + n)
+          in
+          aux 0
+    in
     let rec send omsg =
       match !s with
       | None -> reconnect send omsg
       | Some sock ->
-        let msg = Bytes.of_string (frame_message omsg framing) in
+        let msg = frame omsg |> Bytes.of_string in
         let len = Bytes.length msg in
-        let rec aux idx =
-          let should = len - idx in
-          (Lwt.catch (fun () -> Lwt_unix.send sock msg idx (len - idx) [])
-             (function
-               | Unix.Unix_error (e, f, _) ->
-                 s := None ;
-                 let err = Unix.error_message e in
-                 Printf.eprintf "error %s in function %s, reconnecting\n" err f ;
-                 Lwt.catch
-                   (fun () -> Lwt_unix.close sock)
-                   (function Unix.Unix_error _ -> Lwt.return_unit) >>= fun () ->
-                 reconnect send omsg >|= fun () -> should)) >>= fun n ->
-          if n = should then
-            Lwt.return_unit
-          else
-            aux (idx + n)
-        in
-        aux 0
+        (Lwt.catch (transmit sock msg (Bytes.length msg))
+           (function
+             | Unix.Unix_error (e, f, _) ->
+               s := None ;
+               let err = Unix.error_message e in
+               Printf.eprintf "error %s in function %s, reconnecting\n" err f ;
+               Lwt.catch
+                 (fun () -> Lwt_unix.close sock)
+                 (function Unix.Unix_error _ -> Lwt.return_unit) >>= fun () ->
+               reconnect send omsg))
     in
     at_exit (fun () -> match !s with
         | None -> ()
         | Some x -> Lwt.async (fun () -> Lwt_unix.close x)) ;
-    Lwt.return (Ok (syslog_report_common facility host truncate Ptime_clock.now
-                                         send))
+    Lwt.return (Ok (syslog_report_common facility hostname truncate
+                                         Ptime_clock.now send encode))
+
+let tcp_reporter ?hostname ip ?(port = 514) ?(truncate = 0) ?(framing = `Null) ?facility () =
+  let sa = Lwt_unix.ADDR_INET (ip, port) in
+  let frame msg = frame_message msg framing in
+  let encode = Syslog_message.encode in
+  (match hostname with
+   | Some x -> Lwt.return x
+   | None -> Lwt_unix.gethostname ()) >>= fun host ->
+  conn_reporter Unix.PF_INET Unix.SOCK_STREAM sa truncate frame encode host facility
+
+
+let unix_reporter ?(socket = "/dev/log") ?truncate ?framing ?facility () =
+  let truncate =
+    match truncate with
+    | Some truncate -> truncate
+    | None -> if framing = None then 65536 else 0
+  in
+  let frame, socket_type =
+    match framing with
+    | Some framing -> (fun msg -> frame_message msg framing), Unix.SOCK_STREAM
+    | None -> (fun msg -> msg), Unix.SOCK_DGRAM
+  in
+  let sa = Unix.ADDR_UNIX socket in
+  let encode = Syslog_message.encode_local in
+  conn_reporter Unix.PF_UNIX socket_type sa truncate frame encode "localhost" facility

--- a/src/logs_syslog_lwt.mli
+++ b/src/logs_syslog_lwt.mli
@@ -30,6 +30,23 @@ val tcp_reporter : ?hostname:string -> Lwt_unix.inet_addr -> ?port:int ->
   ?facility:Syslog_message.facility -> unit ->
   (Logs.reporter, string) result Lwt.t
 
+(** [unix_reporter ~socket ~truncate ~framing ()] is [Ok reporter] or
+    [Error msg]. The [reporter] sends each log message via syslog to [socket]
+    (which defaults to ["/dev/log"]). If the initial connection to the socket
+    fails, the log message is reported to standard error, and attempts are made
+    to re-establish the connection. A syslog message is truncated to [truncate]
+    bytes and is framed according to the given [framing]. The default for
+    [truncate] is [65536] if [framing] is not provided and [0] otherwise. If
+    [framing] is not provided, then the socket used is a datagram socket (as
+    for {!udp_reporter}) otherwise a stream socket is used (as for
+    {!tcp_reporter}). [facility] is the default syslog facility (see
+    {!Logs_syslog.message}). *)
+val unix_reporter : ?socket:string ->
+  ?truncate:int ->
+  ?framing:Logs_syslog.framing ->
+  ?facility:Syslog_message.facility -> unit ->
+  (Logs.reporter, string) result Lwt.t
+
 (** {1:lwt_example Example usage}
 
     To install a Lwt syslog reporter, sending via UDP to localhost, use the

--- a/src/logs_syslog_lwt_common.ml
+++ b/src/logs_syslog_lwt_common.ml
@@ -1,6 +1,12 @@
 open Logs_syslog
 
-let syslog_report_common facility host len now send =
+let syslog_report_common
+    facility
+    host
+    len
+    now
+    send
+    (encode : ?len:int -> Syslog_message.t -> string) =
   let report src level ~over k msgf =
     let source = Logs.Src.name src in
     let timestamp = now () in
@@ -12,7 +18,7 @@ let syslog_report_common facility host len now send =
       let msg =
         message ?facility ~host ~source ~tags ?header level timestamp (flush ())
       in
-      let bytes = Syslog_message.encode ~len msg in
+      let bytes = encode ~len msg in
       let unblock () = over () ; Lwt.return_unit in
       Lwt.finalize (fun () -> send bytes) unblock |> Lwt.ignore_result ; k ()
     in

--- a/src/logs_syslog_lwt_common.mli
+++ b/src/logs_syslog_lwt_common.mli
@@ -1,3 +1,4 @@
 val syslog_report_common :
   Syslog_message.facility option -> string -> int -> (unit -> Ptime.t) ->
-  (string -> unit Lwt.t) -> Logs.reporter
+  (string -> unit Lwt.t) -> (?len:int -> Syslog_message.t -> string) ->
+  Logs.reporter

--- a/src/logs_syslog_lwt_tls.ml
+++ b/src/logs_syslog_lwt_tls.ml
@@ -79,7 +79,7 @@ let tcp_tls_reporter
         | None -> ()
         | Some tls -> Lwt.async (fun () -> Tls_lwt.Unix.close tls)) ;
     Lwt.return (Ok (syslog_report_common facility host truncate Ptime_clock.now
-                                         send))
+                                         send Syslog_message.encode))
 
 (*
 let main () =

--- a/src/logs_syslog_mirage.ml
+++ b/src/logs_syslog_mirage.ml
@@ -20,6 +20,7 @@ module Udp (C : Mirage_console_lwt.S) (CLOCK : Mirage_clock.PCLOCK) (STACK : Mir
            Format.(fprintf str_formatter "error %a %s, message: %s"
                      UDP.pp_error e dsts s) ;
            C.log c (Format.flush_str_formatter ()))
+      Syslog_message.encode
 end
 
 module Tcp (C : Mirage_console_lwt.S) (CLOCK : Mirage_clock.PCLOCK) (STACK : Mirage_stack_lwt.V4) = struct
@@ -70,6 +71,7 @@ module Tcp (C : Mirage_console_lwt.S) (CLOCK : Mirage_clock.PCLOCK) (STACK : Mir
             hostname
             truncate
             (fun () -> Ptime.v (CLOCK.now_d_ps clock))
-            send)
+            send
+            Syslog_message.encode)
     | Error e -> Error e
 end

--- a/src/logs_syslog_mirage_tls.ml
+++ b/src/logs_syslog_mirage_tls.ml
@@ -65,6 +65,7 @@ module Tls (C : Mirage_console_lwt.S) (CLOCK : Mirage_clock.PCLOCK) (STACK : Mir
             hostname
             truncate
             (fun () -> Ptime.v (CLOCK.now_d_ps clock))
-            send)
+            send
+            Syslog_message.encode)
     | Error e -> Error e
 end

--- a/src/logs_syslog_unix.ml
+++ b/src/logs_syslog_unix.ml
@@ -1,6 +1,11 @@
 open Logs_syslog
 
-let syslog_report facility host len send =
+let syslog_report
+    facility
+    host
+    len
+    send
+    (encode : ?len:int -> Syslog_message.t -> string) =
   let report src level ~over k msgf =
     let source = Logs.Src.name src in
     let timestamp = Ptime_clock.now () in
@@ -12,7 +17,7 @@ let syslog_report facility host len send =
       let msg =
         message ?facility ~host ~source ~tags ?header level timestamp (flush ())
       in
-      send (Syslog_message.encode ~len msg) ; over () ; k ()
+      send (encode ~len msg) ; over () ; k ()
     in
     msgf @@ fun ?header ?(tags = Logs.Tag.empty) fmt ->
     Format.kfprintf (k tags ?header) ppf fmt
@@ -37,7 +42,7 @@ let udp_reporter
         (Ptime.to_rfc3339 (Ptime_clock.now ()))
         msg
   in
-  syslog_report facility hostname truncate send
+  syslog_report facility hostname truncate send Syslog_message.encode
 
 type state =
   | Disconnected
@@ -46,17 +51,10 @@ type state =
 
 let wait_time = 0.01
 
-let tcp_reporter
-    ?(hostname = Unix.gethostname ())
-    ip
-    ?(port = 514)
-    ?(truncate = 0)
-    ?(framing = `Null)
-    ?facility () =
-  let sa = Unix.ADDR_INET (ip, port) in
+let conn_reporter sd st sa truncate frame encode hostname facility =
   let s = ref Disconnected in
   let connect () =
-    let sock = Unix.(socket PF_INET SOCK_STREAM 0) in
+    let sock = Unix.(socket sd st 0) in
     Unix.(setsockopt sock SO_REUSEADDR true) ;
     Unix.(setsockopt sock SO_KEEPALIVE true) ;
     try
@@ -65,9 +63,15 @@ let tcp_reporter
       Ok ()
     with
     | Unix.Unix_error (e, f, _) ->
+      let endpoint =
+        match sa with
+        | Unix.ADDR_UNIX socket -> socket
+        | Unix.ADDR_INET (ip, port) ->
+            Printf.sprintf "%s:%d" (Unix.string_of_inet_addr ip) port
+      in
       let err =
-        Printf.sprintf "error %s in function %s while connecting to %s:%d\n"
-          (Unix.error_message e) f (Unix.string_of_inet_addr ip) port
+        Printf.sprintf "error %s in function %s while connecting to %s\n"
+          (Unix.error_message e) f endpoint
       in
       Error err
   in
@@ -81,27 +85,61 @@ let tcp_reporter
   match connect () with
   | Error e -> Error e
   | Ok () ->
+    let transmit =
+      if st = Unix.SOCK_DGRAM then
+        fun sock b len -> ignore(Unix.send sock b 0 len [])
+      else
+        fun sock b len ->
+          let rec aux idx =
+            let should = len - idx in
+            let n = Unix.send sock b idx should [] in
+            if n <> should then aux (idx + n)
+          in
+          aux 0
+    in
     let rec send omsg = match !s with
       | Disconnected -> reconnect send omsg
       | Connecting -> let _ = Unix.select [] [] [] wait_time in send omsg
       | Connected sock ->
-        let msg = Bytes.of_string (frame_message omsg framing) in
-        let len = Bytes.length msg in
-        let rec aux idx =
-          try
-            let should = len - idx in
-            let n = Unix.send sock msg idx should [] in
-            if n = should then () else aux (idx + n)
-          with
-          | Unix.Unix_error (Unix.EAGAIN, _, _) -> send omsg
-          | Unix.Unix_error (e, f, _) ->
-            let err = Unix.error_message e in
-            Printf.eprintf "error %s in function %s, reconnecting\n" err f ;
-            (try Unix.close sock with Unix.Unix_error _ -> ()) ;
-            s := Disconnected ;
-            reconnect send omsg
-        in
-        aux 0
+        let msg = frame omsg |> Bytes.of_string in
+        try transmit sock msg (Bytes.length msg) with
+        | Unix.Unix_error (Unix.EAGAIN, _, _) -> send omsg
+        | Unix.Unix_error (e, f, _) ->
+          let err = Unix.error_message e in
+          Printf.eprintf "error %s in function %s, reconnecting\n" err f ;
+          (try Unix.close sock with Unix.Unix_error _ -> ()) ;
+          s := Disconnected ;
+          reconnect send omsg
     in
     at_exit (fun () -> match !s with Connected x -> Unix.close x | _ -> ()) ;
-    Ok (syslog_report facility hostname truncate send)
+    Ok (syslog_report facility hostname truncate send encode)
+
+let tcp_reporter
+    ?(hostname = Unix.gethostname ())
+    ip
+    ?(port = 514)
+    ?(truncate = 0)
+    ?(framing = `Null)
+    ?facility () =
+  let sa = Unix.ADDR_INET (ip, port) in
+  let frame msg = frame_message msg framing in
+  let encode = Syslog_message.encode in
+  let sd = Unix.PF_INET in
+  let st = Unix.SOCK_STREAM in
+  conn_reporter sd st sa truncate frame encode hostname facility
+
+let unix_reporter ?(socket = "/dev/log") ?truncate ?framing ?facility () =
+  let truncate =
+    match truncate with
+    | Some truncate -> truncate
+    | None -> if framing = None then 65536 else 0
+  in
+  let frame, st =
+    match framing with
+    | Some framing -> (fun msg -> frame_message msg framing), Unix.SOCK_STREAM
+    | None -> (fun msg -> msg), Unix.SOCK_DGRAM
+  in
+  let sa = Unix.ADDR_UNIX socket in
+  let encode = Syslog_message.encode_local in
+  let sd = Unix.PF_UNIX in
+  conn_reporter sd st sa truncate frame encode "localhost" facility

--- a/src/logs_syslog_unix.mli
+++ b/src/logs_syslog_unix.mli
@@ -30,6 +30,23 @@ val tcp_reporter : ?hostname:string -> Unix.inet_addr -> ?port:int ->
   ?facility:Syslog_message.facility -> unit ->
   (Logs.reporter, string) result
 
+(** [unix_reporter ~socket ~truncate ~framing ()] is [Ok reporter] or
+    [Error msg]. The [reporter] sends each log message via syslog to [socket]
+    (which defaults to ["/dev/log"]). If the initial connection to the socket
+    fails, the log message is reported to standard error, and attempts are made
+    to re-establish the connection. A syslog message is truncated to [truncate]
+    bytes and is framed according to the given [framing]. The default for
+    [truncate] is [65536] if [framing] is not provided and [0] otherwise. If
+    [framing] is not provided, then the socket used is a datagram socket (as
+    for {!udp_reporter}) otherwise a stream socket is used (as for
+    {!tcp_reporter}). [facility] is the default syslog facility (see
+    {!Logs_syslog.message}). *)
+val unix_reporter : ?socket:string ->
+  ?truncate:int ->
+  ?framing:Logs_syslog.framing ->
+  ?facility:Syslog_message.facility -> unit ->
+  (Logs.reporter, string) result
+
 (** {1:unix_example Example usage}
 
     To install a Unix syslog reporter. sending via UDP to localhost, use the


### PR DESCRIPTION
This PR adds the ability to connect to `/dev/log` and post messages to the local syslog daemon.

This is related to a PR in the syslog-message library, and I'd expect the second commit to be blown away (and the opam file updated) before merging.