### PR TITLE
adapt to syslog-message changes: now includes tag and content instead of message

### DIFF
--- a/src/logs_syslog.ml
+++ b/src/logs_syslog.ml
@@ -31,26 +31,13 @@ let message ?facility:(syslog_facility = Syslog_message.System_Daemons)
       (Logs.Tag.pp_set ppf tags ;
        " " ^ flush ())
   in
-  (* RFC 3164 4.1.3 notes that TAG (in this case, source) can be terminated by
-     any non-alphanumeric character and explictly notes that space is valid.
-     However, colon is more common and in at least one case the space is not
-     sufficient for correct parsing of the message. All this is irrelevant in
-     RFC 5424.
-     (see https://github.com/hannesm/logs-syslog/issues/6) *)
-  let source =
-    let len = String.length source in
-    if len > 0 && source.[len - 1] <> ':' then
-      source ^ ":"
-    else
-      source
-  in
   let hdr = match header with None -> "" | Some x -> " " ^ x in
   (* According to RFC 3164, source should be no more than 32 chars. *)
-  let message = Printf.sprintf "%s%s%s %s" source tags hdr message
+  let content = Printf.sprintf "%s%s %s" tags hdr message
   and severity = slevel level
   in
   { Syslog_message.facility = syslog_facility ; severity ; timestamp ;
-                   hostname ; message }
+                   hostname ; tag = source ; content }
 
 type framing = [
   | `LineFeed


### PR DESCRIPTION
@dra27 please let me know if you'd have considered a different semantics -- should there be a `Astring.String.with_range ~len:32 source` to limit it to fit into the syslog TAG?